### PR TITLE
Cast both sides of flag filter to uint64

### DIFF
--- a/mkidpipeline/photontable.py
+++ b/mkidpipeline/photontable.py
@@ -959,7 +959,7 @@ class Photontable:
 
         excluded = self.flags.bitmask(exclude_flags, unknown='ignore')
         pixcal_hdu = [fits.ImageHDU(data=self._flagArray, name='FLAGS'),
-                      fits.ImageHDU(data=(self._flagArray & excluded).astype(int), name='BAD'),
+                      fits.ImageHDU(data=(np.uint64(self._flagArray) & np.uint64(excluded)).astype(int), name='BAD'),
                       fits.TableHDU.from_columns(np.recarray(shape=flaglist.shape, buf=flaglist,
                                                              dtype=np.dtype([('flags', flaglist.dtype)])),
                                                  name='FLAG_NAMES')]


### PR DESCRIPTION
 This is not strictly safe if we have 64 flags,

A correct fix would be to identify why the self._flagArray Field is an int64 and not a uint64, and why sometimes the flags we want to filter int64 flags and address this issue

Closes #127 